### PR TITLE
Use font descriptors to preserve font attributes in headers.

### DIFF
--- a/Sources/CommonMarkAttributedString/CommonMark+Extensions.swift
+++ b/Sources/CommonMarkAttributedString/CommonMark+Extensions.swift
@@ -104,10 +104,10 @@ extension Heading {
 
         #if canImport(UIKit)
         let font = attributes[.font] as? UIFont ?? UIFont.preferredFont(forTextStyle: .body)
-        attributes[.font] = UIFont(name: font.fontName, size: font.pointSize * fontSizeMultiplier)?.addingSymbolicTraits(.traitBold)
+        attributes[.font] = UIFont(descriptor: font.fontDescriptor, size: font.pointSize * fontSizeMultiplier).addingSymbolicTraits(.traitBold)
         #elseif canImport(AppKit)
         let font = attributes[.font] as? NSFont ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)
-        attributes[.font] = NSFont(name: font.fontName, size: font.pointSize * fontSizeMultiplier)?.addingSymbolicTraits(.bold)
+        attributes[.font] = NSFont(descriptor: font.fontDescriptor, size: font.pointSize * fontSizeMultiplier)?.addingSymbolicTraits(.bold)
         #endif
 
         return attributes

--- a/Sources/CommonMarkAttributedString/NSAttributedString+Extensions.swift
+++ b/Sources/CommonMarkAttributedString/NSAttributedString+Extensions.swift
@@ -44,4 +44,3 @@ extension NSAttributedString {
         self.init(attributedString: mutableAttributedString)
     }
 }
-

--- a/Tests/CommonMarkAttributedStringTests/CommonMarkAttributedStringTests.swift
+++ b/Tests/CommonMarkAttributedStringTests/CommonMarkAttributedStringTests.swift
@@ -68,19 +68,33 @@ final class CommonMarkAttributedStringTests: XCTestCase {
     }
 
     func testHeaderFont() throws {
-        let commonmark = "# Font family should not change"
+        let commonmark = #"""
+        # Helvetica
+
+        > You can say, "I love you," in Helvetica.
+        > And you can say it with Helvetica Extra Light
+        > if you want to be really fancy.
+        > Or you can say it with the Extra Bold
+        > if it's really intensive and passionate, you know,
+        > and it might work.
+        >
+        > ― Massimo Vignelli
+        """#
 
         #if canImport(UIKit)
-        typealias Font = UIFont
-        #elseif canImport(AppKit)
-        typealias Font = NSFont
-        #endif
-
-        let font = Font.boldSystemFont(ofSize: 10)
+        let font = UIFont.boldSystemFont(ofSize: 10)
         let attributedString = try NSAttributedString(commonmark: commonmark, attributes: [.font: font])
         let actualAttributes = attributedString.attributes(at: 0, effectiveRange: nil)
 
-        XCTAssertEqual((actualAttributes[.font] as? Font)?.displayName, font.displayName)
-        XCTAssertGreaterThan((actualAttributes[.font] as? Font)?.pointSize ?? 0, font.pointSize)
+        XCTAssertEqual((actualAttributes[.font] as? UIFont)?.fontName, font.fontName)
+        XCTAssertGreaterThan((actualAttributes[.font] as? UIFont)?.pointSize ?? 0, font.pointSize)
+        #elseif canImport(AppKit)
+        let font = NSFont.boldSystemFont(ofSize: 10)
+        let attributedString = try NSAttributedString(commonmark: commonmark, attributes: [.font: font])
+        let actualAttributes = attributedString.attributes(at: 0, effectiveRange: nil)
+
+        XCTAssertEqual((actualAttributes[.font] as? NSFont)?.displayName, font.displayName)
+        XCTAssertGreaterThan((actualAttributes[.font] as? NSFont)?.pointSize ?? 0, font.pointSize)
+        #endif
     }
 }

--- a/Tests/CommonMarkAttributedStringTests/CommonMarkAttributedStringTests.swift
+++ b/Tests/CommonMarkAttributedStringTests/CommonMarkAttributedStringTests.swift
@@ -66,4 +66,21 @@ final class CommonMarkAttributedStringTests: XCTestCase {
 
         XCTAssert(attributedString.string.starts(with: "Universal Declaration of Human Rights"))
     }
+
+    func testHeaderFont() throws {
+        let commonmark = "# Font family should not change"
+
+        #if canImport(UIKit)
+        typealias Font = UIFont
+        #elseif canImport(AppKit)
+        typealias Font = NSFont
+        #endif
+
+        let font = Font.boldSystemFont(ofSize: 10)
+        let attributedString = try NSAttributedString(commonmark: commonmark, attributes: [.font: font])
+        let actualAttributes = attributedString.attributes(at: 0, effectiveRange: nil)
+
+        XCTAssertEqual((actualAttributes[.font] as? Font)?.displayName, font.displayName)
+        XCTAssertGreaterThan((actualAttributes[.font] as? Font)?.pointSize ?? 0, font.pointSize)
+    }
 }


### PR DESCRIPTION
Fixes #1. 🎉 