### PR TITLE
Fix build with latest CommonMark (0.3.0)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/SwiftDocOrg/CommonMark.git",
         "state": {
           "branch": null,
-          "revision": "347a148fb245aa83327b1765f96143ba39e2f310",
-          "version": "0.2.2"
+          "revision": "9ff339ed62d7ca4b227262bf4c4de6288c5ec3e8",
+          "version": "0.3.0"
         }
       },
       {

--- a/Sources/CommonMarkAttributedString/CommonMark+Extensions.swift
+++ b/Sources/CommonMarkAttributedString/CommonMark+Extensions.swift
@@ -37,7 +37,7 @@ extension Node: AttributedStringConvertible {
 
             return try container.children.map { try $0.attributedString(attributes: attributes, attachments: attachments) }.joined(separator: "\u{2029}")
         case let container as ContainerOfInlineElements:
-            guard !container.children.contains(where: { $0 is HTML }) else {
+            guard !container.children.contains(where: { $0 is RawHTML }) else {
                 let html = try Document(container.description).render(format: .html)
                 return try NSAttributedString(html: html, attributes: attributes) ?? NSAttributedString()
             }


### PR DESCRIPTION
Just stumbled across this when trying to create a playground with CommonMarkAttributed String:

```
/Users/sas/Downloads/cm-test/.build/checkouts/CommonMarkAttributedString/Sources/CommonMarkAttributedString/CommonMark+Extensions.swift:40:63: error: use of undeclared type 'HTML'
            guard !container.children.contains(where: { $0 is HTML }) else {
```

Not an issue in the repo itself because `CommonMark` is pinned to 0.2.2 but on `swift package update` it would break, I believe.

When using this repo here as a dependency, CommonMark will not be pinned and currently does not compile (unless manually pinned to 0.2.2 as well).